### PR TITLE
Enable QR code download

### DIFF
--- a/index.html
+++ b/index.html
@@ -460,8 +460,10 @@ const qrBg = document.getElementById('qr-bg');
 const qrImg = document.getElementById('qr-image');
 const qrDownload = document.getElementById('qr-download');
 document.getElementById('qr-open-btn').onclick = () => {
-  const url = window.location.href.split('#')[0];
-  const src = 'https://chart.googleapis.com/chart?cht=qr&chs=300x300&chl=' + encodeURIComponent(url);
+  const url = 'https://alibek0301.github.io/zholbarys/';
+  const src =
+    'https://chart.googleapis.com/chart?cht=qr&chs=300x300&chl=' +
+    encodeURIComponent(url);
   qrImg.src = src;
   qrDownload.href = src;
   qrBg.style.display = 'flex';


### PR DESCRIPTION
## Summary
- show a QR code pointing at the main website
- allow downloading the QR code

## Testing
- `python3 -m py_compile generate_qr.py`


------
https://chatgpt.com/codex/tasks/task_e_68532a73dc248329bd7da9481d214da1