### PR TITLE
Show QR code at bottom

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,10 +151,9 @@
     .modal-close { position:absolute; top:11px; right:15px; font-size:1.52em; color:#fff; background:none; border:none; cursor:pointer; opacity:.82; transition:.2s;}
     .modal-close:hover { color:var(--main-gold); opacity:1;}
     .modal button[type=submit] {margin-top:10px;}
-    /* QR modal */
-    .qr-bg {display:none; position:fixed; top:0; left:0; width:100vw; height:100vh; background:rgba(25,25,25,0.91); z-index:999; align-items:center; justify-content:center; animation:fadeIn .35s;}
-    .qr-modal { background:#24221a; border-radius:19px; padding:26px 22px 22px 22px; width:100%; max-width:360px; box-shadow:0 7px 38px #0007; position:relative; text-align:center; animation:fadeIn .45s;}
-    .qr-modal img { width:240px; height:240px; }
+    /* QR section */
+    .qr-section { text-align:center; margin:36px 0; }
+    .qr-section img { width:240px; height:240px; }
     .qr-download { margin-top:15px; display:inline-block; background:var(--main-gold); color:var(--main-dark); padding:10px 18px; border-radius:9px; font-weight:700; text-decoration:none; }
     @media(max-width:700px){ .container{padding:12px 1vw 0 1vw;} .card-block{padding:16px 6px 16px 6px;} .logo{width:72px;} .brand{font-size:1.35em;} }
   </style>
@@ -244,7 +243,6 @@
 </div>
 
     <button class="cta" id="open-form-btn">Өтінім қалдыру</button>
-    <button class="cta" id="qr-open-btn" style="margin-left:12px;">QR Code</button>
     <div class="quote-blink" id="quote">
       «Тыныштықты сатып алу мүмкін емес, бірақ бізден тапсырыс беруге болады»
     </div>
@@ -270,13 +268,11 @@
   </div>
 </div>
 
-<!-- QR Modal -->
-<div class="qr-bg" id="qr-bg">
-  <div class="qr-modal" id="qr-modal">
-    <button class="modal-close" id="close-qr" title="Жабу">&times;</button>
-    <img id="qr-image" alt="QR code">
-    <a id="qr-download" class="qr-download" href="" download="qr.png">Download</a>
-  </div>
+
+<!-- QR code at the bottom -->
+<div class="qr-section">
+  <img id="qr-image" alt="QR code">
+  <a id="qr-download" class="qr-download" href="" download="qr.png">Download</a>
 </div>
 
 <div class="footer" id="copyright">&copy; 2007-2024 ТОО "ЖолБарыс Секьюрити". Барлық құқықтар қорғалған.</div>
@@ -307,7 +303,6 @@ const texts = {
     clientsTitle: "Бізге сенім артқандар",
     contactsTitle: "Байланыс",
     cta: "Өтінім қалдыру",
-    qrButton: "QR код",
     qrDownload: "Жүктеп алу",
     form: {
       name: "Атыңыз",
@@ -363,7 +358,6 @@ const texts = {
     clientsTitle: "Нам доверяют",
     contactsTitle: "Контакты",
     cta: "Оставить заявку",
-    qrButton: "QR код",
     qrDownload: "Скачать",
     form: {
       name: "Имя",
@@ -415,7 +409,6 @@ function setLang(l) {
   document.getElementById('clients-title').textContent = texts[lang].clientsTitle;
   document.getElementById('contacts-title').textContent = texts[lang].contactsTitle;
   document.getElementById('open-form-btn').textContent = texts[lang].cta;
-  document.getElementById('qr-open-btn').textContent = texts[lang].qrButton;
   document.getElementById('quote').textContent = texts[lang].quote;
   document.getElementById('label-name').textContent = texts[lang].form.name;
   document.getElementById('label-question').textContent = texts[lang].form.question;
@@ -455,21 +448,15 @@ document.getElementById('open-form-btn').onclick = () => { modalBg.style.display
 document.getElementById('close-modal').onclick = () => { modalBg.style.display = "none"; }
 modalBg.onclick = function(e){ if(e.target===modalBg) modalBg.style.display="none"; };
 
-// QR modal
-const qrBg = document.getElementById('qr-bg');
+// QR code
 const qrImg = document.getElementById('qr-image');
 const qrDownload = document.getElementById('qr-download');
-document.getElementById('qr-open-btn').onclick = () => {
-  const url = 'https://alibek0301.github.io/zholbarys/';
-  const src =
-    'https://chart.googleapis.com/chart?cht=qr&chs=300x300&chl=' +
-    encodeURIComponent(url);
-  qrImg.src = src;
-  qrDownload.href = src;
-  qrBg.style.display = 'flex';
-};
-document.getElementById('close-qr').onclick = () => { qrBg.style.display = 'none'; };
-qrBg.onclick = function(e){ if(e.target===qrBg) qrBg.style.display='none'; };
+const qrUrl = 'https://alibek0301.github.io/zholbarys/';
+const qrSrc =
+  'https://chart.googleapis.com/chart?cht=qr&chs=300x300&chl=' +
+  encodeURIComponent(qrUrl);
+qrImg.src = qrSrc;
+qrDownload.href = qrSrc;
 
 // Отправка формы в WhatsApp
 document.getElementById('order-form').onsubmit = function(e){


### PR DESCRIPTION
## Summary
- display the QR code image at the bottom of the page
- remove modal and button handling

## Testing
- `python3 -m py_compile generate_qr.py`


------
https://chatgpt.com/codex/tasks/task_e_685386d6c2ec8329ad51b40352a6cbfb