### PR TITLE
Fix WhatsApp form message line break encoding

### DIFF
--- a/index.html
+++ b/index.html
@@ -508,9 +508,9 @@ document.getElementById('order-form').onsubmit = function(e){
   const q = document.getElementById('question').value.trim();
   let msg = '';
   if(lang==="kk"){
-    msg = `Сәлеметсіз бе! Менің атым: ${name}.%0AСұрағым: ${q}`;
+    msg = `Сәлеметсіз бе! Менің атым: ${name}.\nСұрағым: ${q}`;
   } else {
-    msg = `Здравствуйте! Меня зовут: ${name}.%0AВопрос: ${q}`;
+    msg = `Здравствуйте! Меня зовут: ${name}.\nВопрос: ${q}`;
   }
   window.open("https://wa.me/77769999697?text=" + encodeURIComponent(msg), "_blank");
   modalBg.style.display = "none";


### PR DESCRIPTION
### Motivation
- Ensure the WhatsApp form message uses real newline characters so `encodeURIComponent` performs correct URL encoding instead of embedding percent-encoded fragments directly.

### Description
- Replaced hardcoded `%0A` fragments with actual `\n` newlines in the `order-form` submit handler in `index.html` for both Kazakh and Russian message templates and continue to open the WhatsApp URL via `encodeURIComponent(msg)`.

### Testing
- Ran a Node.js snippet (`node - <<'NODE' ... NODE`) that constructs the message and verifies `encodeURIComponent` produces `%0A` from `\n`, which succeeded.
- Searched the file for literal `%0A` (`rg -n "%0A" index.html`) and found no matches, confirming the hardcoded fragments were removed.
- Attempted HTML validation with `xmllint --html --noout index.html`, but `xmllint` is not available in the environment (skipped).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ecaa99b408329b9fea0f9d11d34ea)